### PR TITLE
#163189566: add redirect to frontend on password reset link click

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,6 +51,9 @@
     },
     "GOOGLE_SECRET_ID": {
       "required": true
+    },
+    "FRONT_END_DOMAIN": {
+      "required": true
     }
   },
   "formation": {
@@ -58,13 +61,13 @@
       "quantity": 1
     }
   },
-  "addons": [
-    "heroku-postgresql"
-  ],
+  "addons": ["heroku-postgresql"],
   "scripts": {
-    "postdeploy": "./manage makemigrations&&./manage.py migrate --noinput"
+    "postdeploy": "./manage.py makemigrations&&./manage.py migrate --noinput"
   },
-  "buildpacks": [{
-    "url": "heroku/python"
-  }]
+  "buildpacks": [
+    {
+      "url": "heroku/python"
+    }
+  ]
 }

--- a/authors/apps/authentication/test/test_password_reset.py
+++ b/authors/apps/authentication/test/test_password_reset.py
@@ -110,11 +110,7 @@ class TestPasswordReset(APITestCase):
             self.password,
             format='json'
         )
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(
-            json.loads(res.content),
-            {"password": "", "confirm_password": ""}
-        )
+        self.assertEqual(res.status_code, status.HTTP_302_FOUND)
 
     def test_new_short_password(self):
         self.short_password = {

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -36,6 +36,8 @@ from django.core.mail import send_mail
 from django.conf import settings
 from datetime import timedelta
 from django.core.signing import TimestampSigner
+from django.shortcuts import redirect
+import os
 
 
 class RegistrationAPIView(GenericAPIView):
@@ -219,8 +221,17 @@ class PasswordResetConfirmView(RetrieveUpdateAPIView):
     permission_classes = (AllowAny,)
     serializer_class = PasswordResetConfirmSerializer
 
-    def get_object(self):
-        return {"password": "", "confirm_password": ""}
+    def get(self, request, **kwargs):
+        front_end_domain = os.getenv(
+            "FRONT_END_DOMAIN", "http://localhost:3000/")
+
+        slug = kwargs['slug'].split('-')[2]
+        try:
+            username = PasswordResetView().decode_id(slug)
+            User.objects.get(username=username)
+        except:
+            return redirect(front_end_domain+"invalid_link")
+        return redirect(front_end_domain+"password_reset_confirm/"+kwargs['slug'])
 
     def update(self, request, **kwargs):
         serializer_data = request.data


### PR DESCRIPTION
### What does this PR do?
This pull request enables one to be redirected to the frontend when one clicks the password reset link in the email

### Description of tasks to be completed?
Add frontend domain name to the environment variables with key `FRONT_END_DOMAIN`
Write code to redirect to `/password_reset_confirm/:slug` if link is right
Write code to redirect to `/invalid_link` if link is invalid


## How should this be tested?
Use https://ah-backend-athena-stagin-pr-37.herokuapp.com/ to create a user and validate him using the link sent it the email.

Then send POST request to https://ah-backend-athena-stagin-pr-37.herokuapp.com/api/password_reset/ with `{"user": {"email": "email@andela.com"}}` in the body.

### Screen shots
<img width="995" alt="screen shot 2019-01-16 at 15 17 03" src="https://user-images.githubusercontent.com/10868919/51253531-9c136a00-19af-11e9-9a71-65c14b3fa799.png">

<img width="1096" alt="screen shot 2019-01-16 at 15 18 13" src="https://user-images.githubusercontent.com/10868919/51253577-b9483880-19af-11e9-942d-1ebf744c3462.png">
